### PR TITLE
自动战斗准备阶段添加切换指定队伍

### DIFF
--- a/config/programs.json
+++ b/config/programs.json
@@ -148,6 +148,11 @@
                 "custom_action_param": {
                   "group_name": "{value}"
                 }
+              },
+              "开始自动挑战鬼王" :{
+                "custom_action_param": {
+                  "group_name": "{value}"
+                }
               }
             }
           }
@@ -158,6 +163,11 @@
             "default": "默认队伍",
             "pipeline_override": {
               "装备地狱鬼王预设": {
+                "custom_action_param": {
+                  "team_name": "{value}"
+                }
+              },
+              "开始自动挑战鬼王" :{
                 "custom_action_param": {
                   "team_name": "{value}"
                 }

--- a/resource/base/pipeline/自动地鬼.json
+++ b/resource/base/pipeline/自动地鬼.json
@@ -52,6 +52,10 @@
   "开始自动挑战鬼王":{
     "action": "Custom",
     "custom_action": "ChallengeDungeonBoss",
+    "custom_action_param": {
+      "group_name": "地鬼",
+      "team_name": "地域鬼王"
+    },
     "post_delay":2000,
     "next": "返回庭院"
   }


### PR DESCRIPTION
地域鬼王自动战斗时候虽然会在式神录里切换好御魂，但是实际战斗时并不能切换到指定队伍
（需要等该pr合并后我再提交主项目代码